### PR TITLE
Version 1.2.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ModelOrderReductionToolkit"
 uuid = "3b95acbd-20d2-4f07-8ac8-8df51737bf8b"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["fbelik <fjbelik@gmail.com> and contributors"]
 
 [deps]

--- a/docs/src/docs.md
+++ b/docs/src/docs.md
@@ -13,6 +13,8 @@ to_ss
 to_dss
 to_ode_problem
 bode
+poles
+poles_and_vectors
 ```
 
 ### Reductors

--- a/docs/src/docs.md
+++ b/docs/src/docs.md
@@ -15,6 +15,9 @@ to_ode_problem
 bode
 poles
 poles_and_vectors
+observability_gramian
+reachability_gramian
+H2_norm
 ```
 
 ### Reductors

--- a/docs/src/docs.md
+++ b/docs/src/docs.md
@@ -18,6 +18,9 @@ poles_and_vectors
 observability_gramian
 reachability_gramian
 H2_norm
+H2_error
+Hinf_norm
+Hinf_error
 ```
 
 ### Reductors

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -100,7 +100,7 @@ Also implements `to_ss(model[, p=nothing])` to convert a model to a `ControlSyst
 
 ### BT Reductor
 
-The state of the art method for reducing a non-parameterized LTI problem is through balanced truncation. This can be performed with a `BTReductor` object.
+One method for reducing a non-parameterized LTI problem is through balanced truncation. This can be performed with a `BTReductor` object.
 ```@docs
 BTReductor
 ```
@@ -114,6 +114,21 @@ rom = form_rom(reductor, 20)
 ```
 
 See source 4 for more information on the iterative method for solving Lyapunov equations used by `BTReductor` when `iterative==true`, and see `MatrixEquations.jl` for the non-sparse Lyapunov solver. See source 5 for the Penzl model example and for more information on truncation of LTI systems.
+
+### IRKA Reductor
+IRKA is an interpolatory-based method for model reduction of real non-parametric systems, although extensions to parametric systems exist. It is a method for attaining a locally $H_2$ optimal reduced order model through an iterative approach. An `IRKAReductor` for a nonparametric problem (or a parametric problem at fixed `p`) can be formed by either of the following methods.
+```@docs
+IRKAReductor
+```
+
+After iteration, the shifts (opposites of reduced system poles) can be obtained through `irka_reductor.shifts`, and the relative change at each iteration is stored in `irka_reductor.deltas`. As with other reductors, has `form_rom` and `lift` implemented.
+```julia
+model = PenzlModel()
+reductor = IRKAReductor(model, 10)
+rom = form_rom(reductor)
+```
+
+See source 7 for more info on IRKA.
 
 ### RB Reduction
 
@@ -136,3 +151,4 @@ rom = galerkin_project(model, Matrix(reductor.V[:,1:20])) # Faster when converti
 4. Patrick Kürschner and Peter Benner. Efficient low-rank solutions of large-scale matrix equations. Forschungsberichte aus dem Max-Planck-Institut für Dynamik Komplexer Technischer Systeme. 2016. https://pure.mpg.de/rest/items/item_2246796_7/component/file_2296741/content.
 5. Thilo Penzl. Algorithms for model reduction of large dynamical systems. Linear Algebra and its Applications. Volume 415, Issue 2, Pages 322-343. June 1, 2006. https://www.sciencedirect.com/science/article/pii/S0024379506000371.
 6. D.B.P. Huynh, D.J. Knezevic, Y. Chen, J.S. Hesthaven, A.T. Patera. A natural-norm Successive Constraint Method for inf-sup lower bounds. Computer Methods in Applied Mechanics and Engineering. Volume 199, Issue 29. June 1, 2010. https://www.sciencedirect.com/science/article/pii/S0045782510000691.
+7. Baur et al. Interpolatory Projection Methods for Parameterized Model Reduction. SIAM Journal on Scientific Computing. Volume 33, Issue 5. January, 2011. https://epubs.siam.org/doi/10.1137/090776925.

--- a/src/ModelOrderReductionToolkit.jl
+++ b/src/ModelOrderReductionToolkit.jl
@@ -96,5 +96,8 @@ export output_type
 export reachability_gramian
 export observability_gramian
 export H2_norm
+export H2_error
+export Hinf_norm
+export Hinf_error
 
 end

--- a/src/ModelOrderReductionToolkit.jl
+++ b/src/ModelOrderReductionToolkit.jl
@@ -93,5 +93,8 @@ export galerkin_project
 export galerkin_add!
 export output_length
 export output_type
+export reachability_gramian
+export observability_gramian
+export H2_norm
 
 end

--- a/src/ModelOrderReductionToolkit.jl
+++ b/src/ModelOrderReductionToolkit.jl
@@ -31,6 +31,7 @@ include("reductors/pod.jl")
 include("reductors/strong_greedy.jl")
 include("reductors/weak_greedy.jl")
 include("reductors/bt.jl")
+include("reductors/irka.jl")
 # Linear Algebra exports
 export svd
 export qr
@@ -66,6 +67,8 @@ export LinearModel
 export LinearMatrixModel
 export LTIModel
 export bode
+export poles
+export poles_and_vectors
 export to_frequency_domain
 export to_ode_problem
 export to_ss
@@ -78,6 +81,9 @@ export ParameterizedPenzlModel
 export PODReductor
 export SGReductor
 export WGReductor
+export BTReductor
+export SISOIRKAReductor
+export IRKAReductor
 export StabilityResidualErrorEstimator
 export form_rom
 export add_to_rb!
@@ -87,6 +93,5 @@ export galerkin_project
 export galerkin_add!
 export output_length
 export output_type
-export BTReductor
 
 end

--- a/src/la_utils.jl
+++ b/src/la_utils.jl
@@ -343,8 +343,8 @@ function orthonormalize_mgs2!(u::AbstractVector,V::AbstractMatrix)
     return nu
 end
 
-function max_real_numerical_range(A)
-    return largest_real_eigval(0.5 .* (A .+ A'), 1000)
+function max_real_numerical_range(A; reigkwargs...)
+    return reig(0.5 .* (A .+ A'),  which=:L; reigkwargs...)
 end
 
 function nrange(B; nk=1, thmax=32)

--- a/src/reductors/irka.jl
+++ b/src/reductors/irka.jl
@@ -1,0 +1,222 @@
+"""
+`reductor = SISOIRKAReductor(model::LTIModel, r::Int[, p=nothing; init_sigmas=1:r, input_idx=1, output_idx=1, max_iter=50, eps=1e-2, conjugate_tol=1e-6, noise=0])`
+
+`reductor = IRKAReductor(model::LTIModel[, p=nothing; init_sigmas=1:r, max_iter=50, eps=1e-2, conjugate_tol=1e-6, noise=0])`
+
+IRKA reductor object for reducing an `LTIModel`. Must pass in desired reduced order
+model dimension `r`. If parameter `p` passed in, model first initialized to parameter value. 
+Uses `init_sigmas` to determine initial shifts. `SISOIRKAReductor` produces a ROM for a SISO model or 
+focused on a single input (`input_idx`) and output (`output_idx`). Maximum number of IRKA iterations 
+determined by `max_iter`. Proceeds until the relative change in the shifts is less than `eps`. 
+`conjugate_tol` is used to determine whether or not two complex numbers are complex conjugates of each
+other. Use `noise>=1` to print output as the algorithm runs.
+"""
+struct IRKAReductor
+    model::LTIModel
+    shifts::Vector{ComplexF64}
+    deltas::Vector{Float64}
+    V::Matrix{Float64}
+    W::Matrix{Float64}
+    p
+end
+
+function Base.show(io::Core.IO, reductor::IRKAReductor)
+    res  = "IRKA Reductor"
+    println(io, res)
+    print(io, "FOM: ")
+    print(io, reductor.model)
+    if !isnothing(reductor.p)
+        println(io, "")
+        print(io, "Initialized to parameter value $(reductor.p)")
+    end
+end
+
+function compute_relative_set_distance_greedy(a, b, dist_matrix=Matrix{Float64}(undef,length(a),length(b)))
+    dist_matrix .= abs.(a .- transpose(b))
+    res = 0.0
+    for i in eachindex(a)
+        dist, j_choice = findmin(view(dist_matrix,i,:))
+        dist_matrix[:,j_choice] .= Inf
+        dist_matrix[i,j_choice] = dist
+        res += (dist / max(1e-12,abs(a[i]))) ^ 2
+    end
+    return sqrt(res)
+end
+
+function SISOIRKAReductor(model::LTIModel, r::Int, p=nothing; init_sigmas=1:r, input_idx=1, output_idx=1, max_iter=50, eps=1e-2, conjugate_tol=1e-6, noise=0)
+    if !isnothing(p)
+        model(p)
+    elseif is_parameterized(model) && noise >= 1
+        println("No parameter inputted, make sure the LTI model is not parameterized or already initialized to a parameter")
+    end
+    if length(init_sigmas) != r
+        error("length(init_sigmas) must equal r=$r")
+    end
+    @assert isreal(model.A)
+    σs = sort(init_sigmas .+ 0.0im, by=(x -> (real(x),imag(x))))
+    deltas = Float64[]
+    V = Matrix{Float64}(undef, size(model.A,2), r)
+    W = Matrix{Float64}(undef, size(model.A,2), r)
+    b = view(model.B,:,input_idx)
+    c = view(model.C,output_idx,:)
+    dist_matrix = zeros(r,r)
+    for iter in 1:max_iter
+        # Form V and W
+        i = 1
+        while i <= r
+            σ = σs[i]
+            M = factorize(σ*model.E - model.A)
+            v = M \ b
+            w = (M') \ c
+            if i <= r-1 && abs(σ - σs[i+1]') < conjugate_tol
+                v1 = real.(v); orthonormalize_mgs2!(v1, view(V,:,1:(i-1)))
+                w1 = real.(w); orthonormalize_mgs2!(w1, view(W,:,1:(i-1)))
+                V[:,i] .= v1
+                W[:,i] .= w1
+                v2 = imag.(v); orthonormalize_mgs2!(v2, view(V,:,1:i))
+                w2 = imag.(w); orthonormalize_mgs2!(w2, view(W,:,1:i))
+                V[:,i+1] .= v2
+                W[:,i+1] .= w2
+                i += 2
+            else
+                v1 = real.(v); orthonormalize_mgs2!(v1, view(V,:,1:(i-1)))
+                V[:,i] .= v1
+                w1 = real.(w); orthonormalize_mgs2!(w1, view(W,:,1:(i-1)))
+                W[:,i] .= w1
+                i += 1
+            end
+        end
+        # Update W -> W ((W' E V)⁻¹)' such that W' E V = I
+        W .= W / ((W' * model.E * V)')
+        # Form Aᵣ and compute spectrum
+        Ar = W' * model.A * V
+        negλs = sort(-1 .* eigen(Ar).values, by=(x -> (real(x),imag(x))))
+        # Break condition
+        delta = compute_relative_set_distance_greedy(σs, negλs, dist_matrix)
+        if noise >= 1
+            @printf("(%d): Relative error %.4f%%\n", iter, 100 * delta)
+        end
+        push!(deltas, delta)
+        if delta <= eps 
+            break
+        end
+        σs .= negλs
+    end
+    return IRKAReductor(model, σs, deltas, V, W, p)
+end
+
+function IRKAReductor(model::LTIModel, r::Int, p=nothing; init_sigmas=1:r, max_iter=50, eps=1e-2, conjugate_tol=1e-6, noise=0)
+    if !isnothing(p)
+        model(p)
+    elseif is_parameterized(model) && noise >= 1
+        println("No parameter inputted, make sure the LTI model is not parameterized or already initialized to a parameter")
+    end
+    if length(init_sigmas) != r
+        error("length(init_sigmas) must equal r=$r")
+    end
+    @assert isreal(model.A)
+    σs = sort(init_sigmas .+ 0.0im, by=(x -> (real(x),imag(x))))
+    deltas = Float64[]
+    n = size(model.A,2)
+    V = Matrix{Float64}(undef, n, r)
+    W = Matrix{Float64}(undef, n, r)
+    B = model.B; n_in = size(B, 2)
+    C = model.C; n_out = size(C, 1)
+    bs = zeros(ComplexF64, n_in, r)
+    cs = zeros(ComplexF64, n_out, r)
+    i = 1
+    while i <= r
+        if i <= r-1 && abs(σs[i] - σs[i+1]') < conjugate_tol
+            bs[:,i] .= rand(ComplexF64, n_in)
+            bs[:,i+1] .= adjoint.(bs[:,i])
+            cs[:,i] .= rand(ComplexF64, n_out)
+            cs[:,i+1] .= adjoint.(cs[:,i])
+            i += 2
+        else # Conjugate pairs
+            bs[:,i] .= rand(Float64, n_in)
+            cs[:,i] .= rand(Float64, n_out)
+            i += 1
+        end
+    end
+    dist_matrix = zeros(r,r)
+    for iter in 1:max_iter
+        # Form V and W
+        i = 1
+        while i <= r
+            σ = σs[i]
+            M = factorize(σ*model.E - model.A)
+            v = M \ (B * view(bs, :, i))
+            w = (M') \ (C' * view(cs, :, i))
+            if i <= r-1 && abs(σ - σs[i+1]') < conjugate_tol
+                v1 = real.(v); orthonormalize_mgs2!(v1, view(V,:,1:(i-1)))
+                w1 = real.(w); orthonormalize_mgs2!(w1, view(W,:,1:(i-1)))
+                V[:,i] .= v1
+                W[:,i] .= w1
+                v2 = imag.(v); orthonormalize_mgs2!(v2, view(V,:,1:i))
+                w2 = imag.(w); orthonormalize_mgs2!(w2, view(W,:,1:i))
+                V[:,i+1] .= v2
+                W[:,i+1] .= w2
+                i += 2
+            else
+                v1 = real.(v); orthonormalize_mgs2!(v1, view(V,:,1:(i-1)))
+                V[:,i] .= v1
+                w1 = real.(w); orthonormalize_mgs2!(w1, view(W,:,1:(i-1)))
+                W[:,i] .= w1
+                i += 1
+            end
+        end
+        # Update W -> W ((W' E V)⁻¹)' such that W' E V = I
+        W .= W / ((W' * model.E * V)')
+        # Form Aᵣ and compute spectrum
+        Ar = W' * model.A * V
+        Br = W' * B
+        Cr = C * V
+        λ, X = eigen(Ar)
+        bs .= (Br') / X
+        cs .= Cr * X
+        negλs = sort(-1 .* λ, by=(x -> (real(x),imag(x))))
+        # Break condition
+        delta = compute_relative_set_distance_greedy(σs, negλs, dist_matrix)
+        if noise >= 1
+            @printf("(%d): Relative error %.4f%%\n", iter, 100 * delta)
+        end
+        push!(deltas, delta)
+        if delta <= eps 
+            break
+        end
+        σs .= negλs
+    end
+    return IRKAReductor(model, σs, deltas, V, W, p)
+end
+
+"""
+`form_rom(irka_reductor[, r=-1])`
+
+Uses Petrov-Galerkin on the model to form a ROM
+of order `r` (largest possible if `r=-1`). Also,
+initializes it to `irka_reductor.p` if not nothing.
+"""
+function form_rom(irka_reductor::IRKAReductor, r=-1)
+    rom = galerkin_project(irka_reductor.model, irka_reductor.V, irka_reductor.W, WTEVisI=true, r=r)
+    if !isnothing(irka_reductor.p)
+        rom(irka_reductor.p)
+    end
+    return rom
+end
+
+"""
+`lift(irka_reductor, x_r)`
+
+Given a solution array `x_r` to a ROM formed by the
+`irka_reductor` lifts the solution(s) to the same dimension of
+the FOM.   
+"""
+function lift(irka_reductor::IRKAReductor, x_r::AbstractArray)
+    r = size(x_r,1)
+    V = irka_reductor.V
+    if r < size(V, 2)
+        return V[:, 1:r] * x_r
+    else
+        return V * x_r
+    end
+end

--- a/src/reductors/weak_greedy.jl
+++ b/src/reductors/weak_greedy.jl
@@ -208,6 +208,11 @@ function add_to_rb!(wg_reductor::WGReductor{NOUT}, params::AbstractVector; noise
         elseif noise >= 1
             @printf("After orthogonalizing, imaginary part of truth vector had norm %.2e < zero_tol, not appending to RB\n", nx2)
         end
+        if nx1 >= zero_tol && nx2 >= zero_tol
+            # Repush errors to be able to compare with real RB dimension
+            push!(wg_reductor.approx_errors, max_error)
+            push!(wg_reductor.truth_errors, truth_error)
+        end
         if nx1 < zero_tol && nx2 < zero_tol
             return false
         end

--- a/src/residual_norm.jl
+++ b/src/residual_norm.jl
@@ -284,7 +284,7 @@ function ProjectionResidualNormComputer(Ap::APArray,bp::APArray,V::Union{VectorO
                                         Ap, bp, QA, Qb, V, X0)
 end
 
-function update!(res_init::ProjectionResidualNormComputer{T}, v::AbstractVector{T}) where T
+function update!(res_init::ProjectionResidualNormComputer{T}, v::AbstractVector) where T
     Ais = res_init.Ap.arrays
     bis = res_init.bp.arrays
 

--- a/src/scm.jl
+++ b/src/scm.jl
@@ -53,6 +53,8 @@ end
 """
 `ANLSCM{P} <: AbstractSCM <: Function where P <: Int`
 
+WARNING: Below method is experimental and still in development.
+
 An SCM object for an APArray matrix `Ap` which uses nonlinear
 constraining. 
 

--- a/src/vector_of_vectors.jl
+++ b/src/vector_of_vectors.jl
@@ -134,7 +134,7 @@ end
 
 Add the vector `row` to the last column of `vov`.
 """
-function addCol!(vov::VOV{T}, col::AbstractVector{T}) where T
+function addCol!(vov::VOV{T}, col::AbstractVector) where T
     nrows = vov.size[1]
     if length(col) != nrows
         error("New column must have the correct length")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -75,7 +75,7 @@ end
     # Balanced truncation
     bt_reductor = BTReductor(model, p0)
     rom = form_rom(bt_reductor, r)
-    omegas = logrange(1e-2,1e3,100)
+    omegas = 10.0 .^ range(-2,3,100)
     bodeerr = abs.(bode(model, omegas, first=true) .- bode(rom, omegas, first=true))
     @test maximum(bodeerr) < ERR_TOL
     # IRKA

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -77,7 +77,7 @@ end
     # Test Hinf error compared to HSVs
     rom = form_rom(bt_reductor, 10)
     hinferr = Hinf_error(model, rom, p0)
-    @test isapprox(hinferr, 2 * sum(bt_reductor.hs[(r+1):end]), rtol=0.05)
+    @test isapprox(hinferr, 2 * sum(bt_reductor.hs[11:end]), rtol=0.05)
     # Test with r=20
     rom = form_rom(bt_reductor, r)
     omegas = 10.0 .^ range(-2,3,100)
@@ -85,7 +85,6 @@ end
     hinferr = Hinf_error(model, rom, p0)
     @test maximum(bodeerr) < ERR_TOL
     @test hinferr < ERR_TOL
-    @test isapprox(hinferr, 2 * sum(bt_reductor.hs[(r+1):end]), rtol=0.05)
     @test hinferr >= maximum(bodeerr)
     # Test with non-iterative method 
     bt_reductor = BTReductor(model, p0, iterative=false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,6 +74,11 @@ end
     p0 = zeros(3)
     # Balanced truncation
     bt_reductor = BTReductor(model, p0, iterative=true)
+    # Test Hinf error compared to HSVs
+    rom = form_rom(bt_reductor, 10)
+    hinferr = Hinf_error(model, rom, p0)
+    @test isapprox(hinferr, 2 * sum(bt_reductor.hs[(r+1):end]), rtol=0.05)
+    # Test with r=20
     rom = form_rom(bt_reductor, r)
     omegas = 10.0 .^ range(-2,3,100)
     bodeerr = abs.(bode(model, omegas, first=true) .- bode(rom, omegas, first=true))
@@ -82,6 +87,7 @@ end
     @test hinferr < ERR_TOL
     @test isapprox(hinferr, 2 * sum(bt_reductor.hs[(r+1):end]), rtol=0.05)
     @test hinferr >= maximum(bodeerr)
+    # Test with non-iterative method 
     bt_reductor = BTReductor(model, p0, iterative=false)
     rom = form_rom(bt_reductor, r)
     omegas = 10.0 .^ range(-2,3,100)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using SparseArrays
 using LinearAlgebra
 
 @testset "LinearModel" begin
-    model = PoissonModel(Nx=100)
+    model = PoissonModel()
     r = 20; ERR_TOL = 1e-2
     params = [[i,j,k] for i in range(0,1,5) for j in range(0,1,5) for k in range(0,1,5)]
     # POD Reductor

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,9 +78,20 @@ end
     omegas = range(-500,500,1001)
     bodeerr = abs.(bode(model, omegas, first=true) .- bode(rom, omegas, first=true))
     @test maximum(bodeerr) < ERR_TOL
+    # IRKA
+    irka_reductor = IRKAReductor(model, r, p0)
+    rom = form_rom(irka_reductor, r)
+    omegas = range(-500,500,1001)
+    bodeerr = abs.(bode(model, omegas, first=true) .- bode(rom, omegas, first=true))
+    @test maximum(bodeerr) < ERR_TOL
+    # SISO IRKA
+    irka_reductor = SISOIRKAReductor(model, r, p0)
+    rom = form_rom(irka_reductor, r)
+    omegas = range(-500,500,1001)
+    bodeerr = abs.(bode(model, omegas, first=true) .- bode(rom, omegas, first=true))
+    @test maximum(bodeerr) < ERR_TOL
     # RB Method
     freq_model = to_frequency_domain(model)
-    ωs = range(-2,3)
     params = [[ω,i,j,k] for ω in 10.0 .^ range(-2,3,50) for i in range(-40,40,5) for j in range(-40,40,5) for k in range(-40,40,5)]
     rb_reductor = PODReductor(freq_model)
     add_to_rb!(rb_reductor, params)


### PR DESCRIPTION
Added IRKA reductor, and added ability for PODReductor, SGReductor, and WGReductor to force the resulting RB to be real useful for reduction of real LTI systems in the frequency domain. Few small adjustments to Galerkin projections of LTI systems, fix bug in max_numerical_range. Add ability to take a difference between LTI systems. Add computation of H_2 and H_\infty norms for LTI systems and errors between LTI systems.